### PR TITLE
Fixed URL HOME_PAGE now pointing to github

### DIFF
--- a/owlhtml/src/main/java/org/coode/html/impl/OWLHTMLConstants.java
+++ b/owlhtml/src/main/java/org/coode/html/impl/OWLHTMLConstants.java
@@ -37,7 +37,7 @@ import java.net.URL;
  */
 public class OWLHTMLConstants extends ServerConstants {
 
-    public static final URL HOME_PAGE = createURL("http://code.google.com/p/ontology-browser/");
+    public static final URL HOME_PAGE = createURL("https://github.com/co-ode-owl-plugins/ontology-browser");
 
     public static String ONTOLOGY_SERVER_NAME = "Ontology Browser";
 


### PR DESCRIPTION
Hello,

I just noticed in my OWL documentation generated via Protege that the link on the bottom is pointing still to google hosting, so I updated to github